### PR TITLE
[KSTORAGE-829] Remove Kibosh options for compatibility with Kafka server

### DIFF
--- a/file.c
+++ b/file.c
@@ -82,6 +82,15 @@ static int kibosh_open_normal_file_impl(const char *path, int flags,
     // Assume that FUSE has already taken care of the umask.
     snprintf(bpath, sizeof(bpath), "%s%s", fs->root, path);
     file->fd = open(bpath, flags, mode);
+
+    // If new file is created, change the owner to actual user
+    if ((flags & O_CREAT) == O_CREAT)  {
+        if (chown(bpath, fuse_get_context()->uid, fuse_get_context()->gid) < 0) {
+            ret = -errno;
+            goto error;
+        }
+    }
+
     if (file->fd < 0) {
         ret = -errno;
         goto error;

--- a/file.c
+++ b/file.c
@@ -79,22 +79,24 @@ static int kibosh_open_normal_file_impl(const char *path, int flags,
         ret = -ENOMEM;
         goto error;
     }
+
     // Assume that FUSE has already taken care of the umask.
     snprintf(bpath, sizeof(bpath), "%s%s", fs->root, path);
     file->fd = open(bpath, flags, mode);
-
-    // If new file is created, change the owner to actual user
-    if ((flags & O_CREAT) == O_CREAT)  {
-        if (chown(bpath, fuse_get_context()->uid, fuse_get_context()->gid) < 0) {
-            ret = -errno;
-            goto error;
-        }
-    }
 
     if (file->fd < 0) {
         ret = -errno;
         goto error;
     }
+
+    // If new file is created, change the owner to actual user
+    if ((flags & O_CREAT) == O_CREAT)  {
+        if (fchown(file->fd, fuse_get_context()->uid, fuse_get_context()->gid) < 0) {
+            ret = -errno;
+            goto error;
+        }
+    }
+
     info->fh = (uintptr_t)(void*)file;
     return 0;
 

--- a/main.c
+++ b/main.c
@@ -40,6 +40,7 @@ static struct fuse_operations kibosh_oper;
 // FUSE options which we always set.
 static const char * const MANDATORY_FUSE_OPTIONS[] = {
     "-oallow_other", // Allow all users to access the mount point.
+    "-odefault_permissions", // tell FUSE to do permission checking for us based on the reported permissions
     "-ohard_remove", // Do not translate unlink into renames to .fuse_hiddenXXX
     "-oatomic_o_trunc", // Pass O_TRUNC to open()
 };

--- a/main.c
+++ b/main.c
@@ -41,7 +41,7 @@ static struct fuse_operations kibosh_oper;
 static const char * const MANDATORY_FUSE_OPTIONS[] = {
     "-oallow_other", // Allow all users to access the mount point.
     "-odefault_permissions", // tell FUSE to do permission checking for us based on the reported permissions
-    "-odirect_io", // Don't cache data in FUSE.
+    //"-odirect_io", // Don't cache data in FUSE.
     "-ohard_remove", // Do not translate unlink into renames to .fuse_hiddenXXX
     "-oatomic_o_trunc", // Pass O_TRUNC to open()
 };

--- a/main.c
+++ b/main.c
@@ -41,7 +41,6 @@ static struct fuse_operations kibosh_oper;
 static const char * const MANDATORY_FUSE_OPTIONS[] = {
     "-oallow_other", // Allow all users to access the mount point.
     "-odefault_permissions", // tell FUSE to do permission checking for us based on the reported permissions
-    //"-odirect_io", // Don't cache data in FUSE.
     "-ohard_remove", // Do not translate unlink into renames to .fuse_hiddenXXX
     "-oatomic_o_trunc", // Pass O_TRUNC to open()
 };

--- a/main.c
+++ b/main.c
@@ -42,9 +42,6 @@ static const char * const MANDATORY_FUSE_OPTIONS[] = {
     "-oallow_other", // Allow all users to access the mount point.
     "-odefault_permissions", // tell FUSE to do permission checking for us based on the reported permissions
     "-ohard_remove", // Do not translate unlink into renames to .fuse_hiddenXXX
-    "-odirect_io",
-    "-oblkdev,",
-    "-ofsname=vda1",
     "-oatomic_o_trunc", // Pass O_TRUNC to open()
 };
 

--- a/main.c
+++ b/main.c
@@ -42,6 +42,9 @@ static const char * const MANDATORY_FUSE_OPTIONS[] = {
     "-oallow_other", // Allow all users to access the mount point.
     "-odefault_permissions", // tell FUSE to do permission checking for us based on the reported permissions
     "-ohard_remove", // Do not translate unlink into renames to .fuse_hiddenXXX
+    "-odirect_io",
+    "-oblkdev,",
+    "-ofsname=vda1",
     "-oatomic_o_trunc", // Pass O_TRUNC to open()
 };
 

--- a/main.c
+++ b/main.c
@@ -40,7 +40,6 @@ static struct fuse_operations kibosh_oper;
 // FUSE options which we always set.
 static const char * const MANDATORY_FUSE_OPTIONS[] = {
     "-oallow_other", // Allow all users to access the mount point.
-    //"-odefault_permissions", // tell FUSE to do permission checking for us based on the reported permissions
     "-ohard_remove", // Do not translate unlink into renames to .fuse_hiddenXXX
     "-oatomic_o_trunc", // Pass O_TRUNC to open()
 };

--- a/main.c
+++ b/main.c
@@ -40,7 +40,7 @@ static struct fuse_operations kibosh_oper;
 // FUSE options which we always set.
 static const char * const MANDATORY_FUSE_OPTIONS[] = {
     "-oallow_other", // Allow all users to access the mount point.
-    "-odefault_permissions", // tell FUSE to do permission checking for us based on the reported permissions
+    //"-odefault_permissions", // tell FUSE to do permission checking for us based on the reported permissions
     "-ohard_remove", // Do not translate unlink into renames to .fuse_hiddenXXX
     "-oatomic_o_trunc", // Pass O_TRUNC to open()
 };

--- a/meta.c
+++ b/meta.c
@@ -221,6 +221,9 @@ int kibosh_mkdir(const char *path, mode_t mode)
     if (mkdir(bpath, mode) < 0) {
         ret = -errno;
     }
+    if (chown(bpath, fuse_get_context()->uid, fuse_get_context()->gid) < 0) {
+        ret = -errno;
+    }
     DEBUG("kibosh_mkdir(path=%s, bpath=%s, mode=%04o) = %d\n",
           path, bpath, mode, ret);
     return AS_FUSE_ERR(ret);


### PR DESCRIPTION
The FUSE options default_permissions and direct_io cause problems with starting a Kafka server on a Kibosh mounted filesystem. 
Default_permissions option leads to file access permission errors during startup of a Kafka server.
Direct_io option prevents mmap() calls used by Kafka server.