### PR TITLE
[KSTORAGE-830] Add new faults to Kibosh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.so
 *.swp
 build
+.idea

--- a/fault.h
+++ b/fault.h
@@ -25,6 +25,20 @@
 #define KIBOSH_FAULT_TYPE_STR_LEN 32
 
 /**
+ * Constant flags for byte corruption modes.
+ */
+#define CORRUPT_ZERO 1000
+#define CORRUPT_RAND 1001
+#define CORRUPT_ZERO_SEQ 1100
+#define CORRUPT_RAND_SEQ 1101
+#define CORRUPT_DROP 1200
+
+/**
+ * Generate a random double between 0 and 1.0
+ */
+#define RAND_FRAC ((double)rand()/(double)RAND_MAX)
+
+/**
  * Base class for Kibosh faults.
  */
 struct kibosh_fault_base {
@@ -43,6 +57,21 @@ struct kibosh_fault_base {
  * The type of kibosh_fault_read_delay.
  */
 #define KIBOSH_FAULT_TYPE_READ_DELAY "read_delay"
+
+/**
+* The type of kibosh_fault_unwritable.
+*/
+#define KIBOSH_FAULT_TYPE_UNWRITABLE "unwritable"
+
+/**
+* The type of kibosh_fault_read_corrupt.
+*/
+#define KIBOSH_FAULT_TYPE_READ_CORRUPT "read_corrupt"
+
+/**
+* The type of kibosh_fault_write_corrupt.
+*/
+#define KIBOSH_FAULT_TYPE_WRITE_CORRUPT "write_corrupt"
 
 /**
  * The class for Kibosh faults that make files unreadable.
@@ -85,6 +114,96 @@ struct kibosh_fault_read_delay {
 
     /**
      * The fraction of reads that are delayed.
+     */
+    double fraction;
+};
+
+/**
+* The class for Kibosh faults that make files unwritable.
+*/
+struct kibosh_fault_unwritable {
+    /**
+    * The base class members.
+    */
+    struct kibosh_fault_base base;
+
+    /**
+    * The path prefix.
+    */
+    char *prefix;
+
+    /**
+    * The error code to return from write faults.
+    */
+    int code;
+};
+
+/**
+* The class for Kibosh faults that lead to corrupted data when reading.
+*/
+struct kibosh_fault_read_corrupt {
+    /**
+    * The base class members.
+    */
+    struct kibosh_fault_base base;
+
+    /**
+    * The path prefix.
+    */
+    char *prefix;
+
+    /**
+    * The type of file to be corrupted.
+    */
+    char *file_type;
+
+    /**
+     * Mode of byte corruption.
+     * 1000 -> zeros (default)
+     * 1001 -> random values
+     * 1100 -> sequential zeros
+     * 1101 -> sequential random values
+     * 1200 -> drop a fraction of buffer
+     */
+    int mode;
+
+    /**
+     * The fraction of bytes corrupted. (Default = 0.5)
+     */
+    double fraction;
+};
+
+/**
+* The class for Kibosh faults that lead to corrupted data when writing.
+*/
+struct kibosh_fault_write_corrupt {
+    /**
+    * The base class members.
+    */
+    struct kibosh_fault_base base;
+
+    /**
+    * The path prefix.
+    */
+    char *prefix;
+
+    /**
+    * The type of file to be corrupted.
+    */
+    char *file_type;
+
+    /**
+     * Mode of byte corruption.
+     * 1000 -> zeros (default)
+     * 1001 -> random values
+     * 1100 -> sequential zeros
+     * 1101 -> sequential random values
+     * 1200 -> drop a fraction of buffer
+     */
+    int mode;
+
+    /**
+     * The fraction of bytes corrupted. (Default = 0.5)
      */
     double fraction;
 };

--- a/fs.c
+++ b/fs.c
@@ -296,4 +296,13 @@ int kibosh_fs_check_read_fault(struct kibosh_fs *fs, const char *path)
     return ret;
 }
 
+int kibosh_fs_check_write_fault(struct kibosh_fs *fs, const char *path)
+{
+    int ret;
+    pthread_mutex_lock(&fs->lock);
+    ret = faults_check(fs->faults, path, "write");
+    pthread_mutex_unlock(&fs->lock);
+    return ret;
+}
+
 // vim: ts=4:sw=4:tw=99:et

--- a/fs.h
+++ b/fs.h
@@ -126,6 +126,16 @@ int kibosh_fs_accessor_fd_release(struct kibosh_fs *fs, int fd);
  */
 int kibosh_fs_check_read_fault(struct kibosh_fs *fs, const char *path);
 
+/**
+ * Check if we should inject a write fault.
+ *
+ * @param fs        The kibosh_fs.
+ * @param path      The path being written to.
+ *
+ * @return          0 if we should not inject a fault; the error code otherwise.
+ */
+int kibosh_fs_check_write_fault(struct kibosh_fs *fs, const char *path);
+
 #endif
 
 // vim: ts=4:sw=4:tw=99:et

--- a/main.c
+++ b/main.c
@@ -41,7 +41,7 @@ static struct fuse_operations kibosh_oper;
 static const char * const MANDATORY_FUSE_OPTIONS[] = {
     "-oallow_other", // Allow all users to access the mount point.
     "-odefault_permissions", // tell FUSE to do permission checking for us based on the reported permissions
-    "-odirect_io", // Don't cache data in FUSE.
+    //"-odirect_io", // Don't cache data in FUSE.
     "-ohard_remove", // Do not translate unlink into renames to .fuse_hiddenXXX
     "-oatomic_o_trunc", // Pass O_TRUNC to open()
 };

--- a/main.c
+++ b/main.c
@@ -41,7 +41,6 @@ static struct fuse_operations kibosh_oper;
 static const char * const MANDATORY_FUSE_OPTIONS[] = {
     "-oallow_other", // Allow all users to access the mount point.
     "-odefault_permissions", // tell FUSE to do permission checking for us based on the reported permissions
-    //"-odirect_io", // Don't cache data in FUSE.
     "-ohard_remove", // Do not translate unlink into renames to .fuse_hiddenXXX
     "-oatomic_o_trunc", // Pass O_TRUNC to open()
 };

--- a/meta.c
+++ b/meta.c
@@ -221,6 +221,9 @@ int kibosh_mkdir(const char *path, mode_t mode)
     if (mkdir(bpath, mode) < 0) {
         ret = -errno;
     }
+    if (chown(bpath, fuse_get_context()->uid, fuse_get_context()->gid) < 0) {
+        ret = -errno;
+    }
     DEBUG("kibosh_mkdir(path=%s, bpath=%s, mode=%04o) = %d\n",
           path, bpath, mode, ret);
     return AS_FUSE_ERR(ret);

--- a/time.h
+++ b/time.h
@@ -18,6 +18,7 @@
 #define KIBOSH_TIME_H
 
 #include <stdint.h> // for uint32_t
+#include <time.h>
 
 struct timespec;
 

--- a/util.h
+++ b/util.h
@@ -19,6 +19,7 @@
 
 #include "json.h" // for json_value
 #include <unistd.h> // for size_t
+#include <math.h> // for round()
 
 /**
  * Like snprintf, but appends to a string that already exists.


### PR DESCRIPTION
- Added unwritable and read_corrupt faults to Kibosh.
-- Unwritable fault will intercept write system calls and return a user specified error code when injected.
-- Read_corrupt fault will read and return corrupted data when injected.
-- Write_corrupt fault will write corrupt data to file when injected.
- Data corrupt modes are standardized as constants for both read and write corrupt faults.
- Implemented fraction feature for read_delay fault
- Some minor bug fix.